### PR TITLE
feat: Implement 5 basic Shopify landing page sections (#8)

### DIFF
--- a/sections/footer-section.liquid
+++ b/sections/footer-section.liquid
@@ -1,0 +1,59 @@
+{% schema %}
+  {
+    "name": "Footer",
+    "settings": [
+      {
+        "type": "richtext",
+        "id": "copyright_text",
+        "label": "Copyright Text",
+        "default": "<p>&copy; {{ now | date: \"%Y\" }} Your Store Name</p>"
+      }
+    ],
+    "blocks": [
+      {
+        "type": "link_list",
+        "name": "Menu",
+        "settings": [
+          {
+            "type": "text",
+            "id": "heading",
+            "label": "Heading",
+            "default": "Quick Links"
+          },
+          {
+            "type": "link_list",
+            "id": "menu",
+            "label": "Menu to display"
+          }
+        ]
+      }
+    ],
+    "presets": [
+      {
+        "name": "Footer"
+      }
+    ]
+  }
+{% endschema %}
+
+<footer class="footer-section">
+  <div class="footer-content">
+    {% for block in section.blocks %}
+      {% case block.type %}
+        {% when link_list %}
+          <div class="footer-menu">
+            <h3>{{ block.settings.heading }}</h3>
+            <ul>
+              {% for link in block.settings.menu.links %}
+                <li><a href="{{ link.url }}">{{ link.title }}</a></li>
+              {% endfor %}
+            </ul>
+          </div>
+      {% endcase %}
+    {% endfor %}
+  </div>
+  <div class="footer-copyright">
+    {{ section.settings.copyright_text }}
+  </div>
+</footer>
+

--- a/sections/hero-section.liquid
+++ b/sections/hero-section.liquid
@@ -1,0 +1,44 @@
+{% schema %}
+  {
+    "name": "Hero Section",
+    "settings": [
+      {
+        "type": "text",
+        "id": "heading",
+        "label": "Heading",
+        "default": "Welcome to our Store"
+      },
+      {
+        "type": "richtext",
+        "id": "subheading",
+        "label": "Subheading",
+        "default": "<p>Discover amazing products</p>"
+      },
+      {
+        "type": "url",
+        "id": "button_link",
+        "label": "Button Link"
+      },
+      {
+        "type": "text",
+        "id": "button_label",
+        "label": "Button Label",
+        "default": "Shop Now"
+      }
+    ],
+    "presets": [
+      {
+        "name": "Hero Section"
+      }
+    ]
+  }
+{% endschema %}
+
+<section class="hero-section">
+  <h1>{{ section.settings.heading }}</h1>
+  <div>{{ section.settings.subheading }}</div>
+  {% if section.settings.button_link != blank and section.settings.button_label != blank %}
+    <a href="{{ section.settings.button_link }}">{{ section.settings.button_label }}</a>
+  {% endif %}
+</section>
+

--- a/sections/product-grid.liquid
+++ b/sections/product-grid.liquid
@@ -1,0 +1,48 @@
+{% schema %}
+  {
+    "name": "Product Grid",
+    "settings": [
+      {
+        "type": "text",
+        "id": "title",
+        "label": "Heading",
+        "default": "Featured Products"
+      },
+      {
+        "type": "collection",
+        "id": "collection",
+        "label": "Collection to display"
+      },
+      {
+        "type": "range",
+        "id": "products_to_show",
+        "min": 2,
+        "max": 12,
+        "step": 1,
+        "label": "Products to show",
+        "default": 4
+      }
+    ],
+    "presets": [
+      {
+        "name": "Product Grid"
+      }
+    ]
+  }
+{% endschema %}
+
+<section class="product-grid">
+  <h2>{{ section.settings.title }}</h2>
+  <div class="product-items">
+    {% for product in section.settings.collection.products limit: section.settings.products_to_show %}
+      <div class="product-item">
+        <a href="{{ product.url }}">
+          <img src="{{ product.featured_image | image_url: width: 300 }}" alt="{{ product.featured_image.alt | escape }}">
+          <h3>{{ product.title }}</h3>
+          <p>{{ product.price | money }}</p>
+        </a>
+      </div>
+    {% endfor %}
+  </div>
+</section>
+

--- a/sections/testimonials.liquid
+++ b/sections/testimonials.liquid
@@ -1,0 +1,51 @@
+{% schema %}
+  {
+    "name": "Testimonials",
+    "settings": [
+      {
+        "type": "text",
+        "id": "heading",
+        "label": "Heading",
+        "default": "What Our Customers Say"
+      }
+    ],
+    "blocks": [
+      {
+        "type": "testimonial",
+        "name": "Testimonial",
+        "settings": [
+          {
+            "type": "richtext",
+            "id": "quote",
+            "label": "Quote",
+            "default": "<p>This is an amazing product!</p>"
+          },
+          {
+            "type": "text",
+            "id": "author",
+            "label": "Author",
+            "default": "Customer Name"
+          }
+        ]
+      }
+    ],
+    "presets": [
+      {
+        "name": "Testimonials"
+      }
+    ]
+  }
+{% endschema %}
+
+<section class="testimonials-section">
+  <h2>{{ section.settings.heading }}</h2>
+  <div class="testimonials-grid">
+    {% for block in section.blocks %}
+      <div class="testimonial-item">
+        <div class="quote">{{ block.settings.quote }}</div>
+        <p class="author">- {{ block.settings.author }}</p>
+      </div>
+    {% endfor %}
+  </div>
+</section>
+

--- a/sections/text-with-image.liquid
+++ b/sections/text-with-image.liquid
@@ -1,0 +1,40 @@
+{% schema %}
+  {
+    "name": "Text with Image",
+    "settings": [
+      {
+        "type": "image_picker",
+        "id": "image",
+        "label": "Image"
+      },
+      {
+        "type": "text",
+        "id": "heading",
+        "label": "Heading",
+        "default": "Title of Section"
+      },
+      {
+        "type": "richtext",
+        "id": "text",
+        "label": "Text",
+        "default": "<p>Add your descriptive text here.</p>"
+      }
+    ],
+    "presets": [
+      {
+        "name": "Text with Image"
+      }
+    ]
+  }
+{% endschema %}
+
+<section class="text-with-image">
+  {% if section.settings.image != blank %}
+    <img src="{{ section.settings.image | image_url: width: 400 }}" alt="{{ section.settings.image.alt | escape }}">
+  {% endif %}
+  <div>
+    <h2>{{ section.settings.heading }}</h2>
+    <div>{{ section.settings.text }}</div>
+  </div>
+</section>
+


### PR DESCRIPTION
Closes #8\n\n## Changes\n- Implemented 5 basic Shopify sections for a landing page:\n  - : Heading, subheading, button.\n  - : Image with accompanying text and heading.\n  - : Displays products from a selected collection.\n  - : Displays customer testimonials with quotes and authors.\n  - : Basic footer with copyright and link list blocks.\n\nEach section includes a basic schema for customization in the Shopify theme editor.\n\n## Testing\n- N/A (structural and placeholder content only)